### PR TITLE
Currency formatter was returning a NaN string with null input. On the interface - the user was able to see R$ NaN as value

### DIFF
--- a/web/src/helpers/currencyFormatter.js
+++ b/web/src/helpers/currencyFormatter.js
@@ -1,4 +1,8 @@
 export default function currencyFormatter(value, currency, locale) {
+  if (!value && value !== 0) {
+    return '';
+  }
+  
   const realValue = value / 100;
   if (!currency) {
     currency = 'BRL';

--- a/web/src/views/PayableDetail.vue
+++ b/web/src/views/PayableDetail.vue
@@ -19,7 +19,7 @@
     <div class="dashed mt-3" :class="totalAmountColor"></div>
     <div class="py-2" :class="totalAmountColor">
       <div class="ls-row ls-no-gutters ls-align-items-center">
-        <div class="ls-col mr-3" v-if="payable.amountTotal">
+        <div class="ls-col mr-3" v-if="amountTotal">
           <div class="amount-label">Valor total</div>
           <span class="amount" :class="totalAmountColor" style="white-space: nowrap">
             {{ amountTotal }}
@@ -40,7 +40,7 @@
             {{ amountOriginal }}
           </span>
         </div>
-        <div v-if="payable.amountPaid" class="ls-col mt-3">
+        <div v-if="amountPaid" class="ls-col mt-3">
           <div class="amount-label">Valor pago</div>
           <span class="amount success--text" style="white-space: nowrap">
             {{ amountPaid }}


### PR DESCRIPTION
Com a alteracao proposta, agora a funcao currencyFormatter, caso identifique se tratar de um caso onde o valor eh nulo, retorna uma string vazia - mantendo o contrato da funcao porem sendo um valor do tipo falsey. Todos os lugares onde isso ocorre nao virao mais como NaN, mas sim como string vazia - eh esperado que o componente que utilizar essa funcao faca o v-if correto para nao expor a string vazia para o usuario